### PR TITLE
Issue #195 - sitedata pathnames on windows are wrong

### DIFF
--- a/lib/custom-utils.js
+++ b/lib/custom-utils.js
@@ -97,14 +97,18 @@ const removeIndex = (page) =>
   return pathname;
 };
 
+const getPagePathNoIndex = (filePath) =>
+{
+  return removeIndex(path.relative(pageDir, filePath));
+};
+
 /**
  * Get pathname from the full path to the page
  * @param {String} filePath Full path to the page
  */
 const getOriginalPathname = (filePath) =>
 {
-  const relativePathNoIndex = removeIndex(path.relative(pageDir, filePath));
-  return relativePathNoIndex.split(path.sep).join("/");
+  return getPagePathNoIndex(filePath).split(path.sep).join("/");
 };
 
 /**
@@ -153,4 +157,5 @@ const glob = (...args) =>
 };
 
 module.exports = {parseAttributes, getDeepValue, removeIndex,
-  getOriginalPathname, getPathname, pathnameToPath, urlPathJoin, glob};
+  getPagePathNoIndex, getOriginalPathname, getPathname, pathnameToPath,
+  urlPathJoin, glob};

--- a/lib/custom-utils.js
+++ b/lib/custom-utils.js
@@ -103,7 +103,8 @@ const removeIndex = (page) =>
  */
 const getOriginalPathname = (filePath) =>
 {
-  return removeIndex(path.relative(pageDir, filePath));
+  const relativePathNoIndex = removeIndex(path.relative(pageDir, filePath));
+  return relativePathNoIndex.split(path.sep).join("/");
 };
 
 /**

--- a/lib/custom-utils.js
+++ b/lib/custom-utils.js
@@ -97,13 +97,18 @@ const removeIndex = (page) =>
   return pathname;
 };
 
+/**
+ * Create relative path to relevant page
+ * @param {String} filePath path to the page file
+ * @return {String}
+ */
 const getPagePathNoIndex = (filePath) =>
 {
   return removeIndex(path.relative(pageDir, filePath));
 };
 
 /**
- * Get pathname from the full path to the page
+ * Get URL pathname from the full path to the page
  * @param {String} filePath Full path to the page
  */
 const getOriginalPathname = (filePath) =>

--- a/lib/custom-utils.js
+++ b/lib/custom-utils.js
@@ -84,12 +84,13 @@ let getDeepValue = (attributes, obj) =>
 };
 
 /**
- * Remove index part from the page
- * @param  {String}   page  Path to the page
+ * Creates File System request representation from file path
+ * @param {String} filePath path to the page file
  * @return {String}
  */
-const removeIndex = (page) =>
+const pagePathFromFile = (filePath) =>
 {
+  const page = path.relative(pageDir, filePath);
   const {dir, name} = path.parse(page);
   let pathname = dir;
   if (name != "index")
@@ -98,22 +99,12 @@ const removeIndex = (page) =>
 };
 
 /**
- * Create relative path to relevant page
- * @param {String} filePath path to the page file
- * @return {String}
- */
-const getPagePathNoIndex = (filePath) =>
-{
-  return removeIndex(path.relative(pageDir, filePath));
-};
-
-/**
- * Get URL pathname from the full path to the page
+ * Creates URL pathname from the full path to the file
  * @param {String} filePath Full path to the page
  */
-const getOriginalPathname = (filePath) =>
+const originalPathnameFromFile = (filePath) =>
 {
-  return getPagePathNoIndex(filePath).split(path.sep).join("/");
+  return pagePathFromFile(filePath).split(path.sep).join("/");
 };
 
 /**
@@ -126,7 +117,7 @@ const getPathname = (pagePath, attributes) =>
   if (attributes.permalink)
     return attributes.permalink;
   else
-    return getOriginalPathname(pagePath);
+    return originalPathnameFromFile(pagePath);
 };
 
 /**
@@ -161,6 +152,5 @@ const glob = (...args) =>
     path.replace(/\//g, separator)));
 };
 
-module.exports = {parseAttributes, getDeepValue, removeIndex,
-  getPagePathNoIndex, getOriginalPathname, getPathname, pathnameToPath,
-  urlPathJoin, glob};
+module.exports = {parseAttributes, getDeepValue, pagePathFromFile,
+  originalPathnameFromFile, getPathname, pathnameToPath, urlPathJoin, glob};

--- a/lib/sitedata.js
+++ b/lib/sitedata.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const {promisify} = require("util");
 const readFile = promisify(fs.readFile);
 const frontMatter = require("front-matter");
-const {getOriginalPathname, getPagePathNoIndex,
+const {originalPathnameFromFile, pagePathFromFile,
   getPathname, glob} = require("./custom-utils");
 
 const {pageDir} = require("../config").dirs;
@@ -42,12 +42,12 @@ function createSitedata(callback)
         if (data.attributes.permalink)
         {
           // Add to permlinks
-          const pathname = getPagePathNoIndex(filePath);
+          const pathname = pagePathFromFile(filePath);
           permalinktoPageMap[data.attributes.permalink] = pathname;
         }
 
         data.attributes.pathname = getPathname(filePath, data.attributes);
-        data.attributes.originalPathname = getOriginalPathname(filePath);
+        data.attributes.originalPathname = originalPathnameFromFile(filePath);
         pageDatas.push(data.attributes);
 
         if (filesStack.length === 0)
@@ -64,7 +64,7 @@ const getPermalinkedPage = function(pathname)
 
 const getPagePermalink = function(path)
 {
-  const pagePath = getPagePathNoIndex(path);
+  const pagePath = pagePathFromFile(path);
   return Object.keys(permalinktoPageMap).find((key) =>
     permalinktoPageMap[key] === pagePath);
 };

--- a/lib/sitedata.js
+++ b/lib/sitedata.js
@@ -4,7 +4,8 @@ const fs = require("fs");
 const {promisify} = require("util");
 const readFile = promisify(fs.readFile);
 const frontMatter = require("front-matter");
-const {getOriginalPathname, getPathname, glob} = require("./custom-utils");
+const {getOriginalPathname, getPagePathNoIndex,
+  getPathname, glob} = require("./custom-utils");
 
 const {pageDir} = require("../config").dirs;
 
@@ -41,7 +42,7 @@ function createSitedata(callback)
         if (data.attributes.permalink)
         {
           // Add to permlinks
-          const pathname = getOriginalPathname(filePath);
+          const pathname = getPagePathNoIndex(filePath);
           permalinktoPageMap[data.attributes.permalink] = pathname;
         }
 
@@ -63,9 +64,9 @@ const getPermalinkedPage = function(pathname)
 
 const getPagePermalink = function(path)
 {
-  const originalPathname = getOriginalPathname(path);
+  const pagePath = getPagePathNoIndex(path);
   return Object.keys(permalinktoPageMap).find((key) =>
-    permalinktoPageMap[key] === originalPathname);
+    permalinktoPageMap[key] === pagePath);
 };
 
 const isPagePermalinked = function(path)

--- a/test/lib/sitedata.js
+++ b/test/lib/sitedata.js
@@ -17,7 +17,27 @@ const siteDataTests = [
     filter: (data) => data.pathname === "another/sitedata/permalink",
     attributeName: "pathname",
     result: "another/sitedata/permalink"
-  }
+  },
+  {
+    filter: (data) => data.pathname === "sitedata/subfolder/path",
+    attributeName: "pathname",
+    result: "sitedata/subfolder/path"
+  },
+  {
+    filter: (data) => data.pathname === "sitedata/subfolder/path",
+    attributeName: "originalPathname",
+    result: "sitedata/subfolder/path"
+  },
+  {
+    filter: (data) => data.pathname === "sitedata/subfolder",
+    attributeName: "pathname",
+    result: "sitedata/subfolder"
+  },
+  {
+    filter: (data) => data.pathname === "sitedata/subfolder",
+    attributeName: "originalPathname",
+    result: "sitedata/subfolder"
+  },
 ];
 
 for (const siteDataTest of siteDataTests)

--- a/test/src/pages/sitedata/subfolder/index.md
+++ b/test/src/pages/sitedata/subfolder/index.md
@@ -1,0 +1,6 @@
+---
+title: Sitedata test
+layout: default
+---
+
+## Sitedata test

--- a/test/src/pages/sitedata/subfolder/path.md
+++ b/test/src/pages/sitedata/subfolder/path.md
@@ -1,0 +1,6 @@
+---
+title: Sitedata test
+layout: default
+---
+
+## Sitedata test


### PR DESCRIPTION
Even though quite a lot of Windows related issues were fixed by https://github.com/cmints/cmints/pull/196 one of the most important issues unfortunately didn't have test coverage and went unnoticed. Current PR contain:
- Added tests to ensure `pathname` and `originalPathname` does use correct URL path separators on all OS.
- Separated `originalPathnameFromFile` and `pagePathFromFile` - former one is used to get actual URL representation of the file path, while the former one is used for creating fileSystem representation.
- Ensured to use `originalPathnameFromFile` for reason to create URL path representation, as previously this was being used as `pagePathFromFile` is used now.